### PR TITLE
Add Github Action check for max changed lines of code in PR

### DIFF
--- a/{{cookiecutter.project_name}}/.github/actions/large-pr-check/action.yaml
+++ b/{{cookiecutter.project_name}}/.github/actions/large-pr-check/action.yaml
@@ -1,0 +1,49 @@
+name: "Large PR checker"
+description: "Blocks PR if number of lines changed is excessive. Modified version of https://github.com/adolfosilva/gh-large-pr-check/blob/main/action.yml"
+
+inputs:
+  max_lines_changed:
+    description: "Maximum number of lines changed allowed"
+    required: true
+    default: "500"
+  target_branch:
+    description: The branch to compare against
+    required: true
+    default: main
+outputs:
+  total_lines_changed:
+    description: "Total lines changed in this PR"
+    value: ${{ steps.get_total_lines_changed.outputs.total_lines_changed }}
+
+runs:
+  using: "composite"
+  steps:
+    - id: fetch_target_branch
+      run: |
+        git fetch origin ${{ inputs.target_branch }}
+      shell: bash
+    - id: get_total_lines_changed
+      run: |
+        size=$(git diff --shortstat origin/${{ inputs.target_branch }} ':(exclude)*.lock' \
+        | awk '{ print $4+$6 }' \
+        | awk -F- '{print $NF}' \
+        | bc)
+
+        echo ""
+        echo "Total lines changed (note: *.lock files are excluded from this count): $size"
+        echo "total_lines_changed=$size" >> $GITHUB_OUTPUT
+      shell: bash
+    - name: Comment PR
+      if: ${{ fromJSON(steps.get_total_lines_changed.outputs.total_lines_changed) > fromJSON(inputs.max_lines_changed) }}
+      uses: thollander/actions-comment-pull-request@v2
+      with:
+        comment_tag: pr_size
+        mode: recreate
+        message: |
+          :boom: :boom: :boom:
+          Total lines changed ${{ steps.get_total_lines_changed.outputs.total_lines_changed }} is greater than ${{ inputs.max_lines_changed }}.
+          Please consider breaking this PR down.
+    - id: fail
+      if: ${{ fromJSON(steps.get_total_lines_changed.outputs.total_lines_changed) > fromJSON(inputs.max_lines_changed) }}
+      run: exit 1
+      shell: bash

--- a/{{cookiecutter.project_name}}/.github/workflows/pr.yaml
+++ b/{{cookiecutter.project_name}}/.github/workflows/pr.yaml
@@ -1,0 +1,21 @@
+name: Validate & Lint & Test
+
+on: [pull_request]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check-pr-diff:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Check PR diff size
+        uses: ./.github/actions/large-pr-check
+        with:
+          target_branch: ${{ github.event.pull_request.base.ref }}
+          max_lines_changed: 100

--- a/{{cookiecutter.project_name}}/Makefile
+++ b/{{cookiecutter.project_name}}/Makefile
@@ -76,3 +76,8 @@ lint:
 
 safety:
 	poetry run safety check --policy-file=.safety-policy.yml
+
+check-changed-loc:
+	chmod +x ./scripts/pr-max-diff-checker.sh
+	# WARNING: Adopt arguments for project specific requirements
+	./scripts/pr-max-diff-checker.sh 300 origin/master

--- a/{{cookiecutter.project_name}}/scripts/pr-max-diff-checker.sh
+++ b/{{cookiecutter.project_name}}/scripts/pr-max-diff-checker.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+# Script helps to block Pull Requests with exceeded number of changed lines of code.
+# Firstly, it compares HEAD with source branch
+# Then it counts changed lines of code, excluding specified files and respecting max lines of code
+
+# Read first input arg or take default value - 500
+MAX_CHANGED_LOC="${1:-500}"
+
+# Second argument (source branch) is required
+if [ -z "$2" ]; then
+  echo "No remote source branch supplied"
+  exit 1
+else
+  source_branch=$2
+fi
+
+# Parse such line `2 files changed, 18 insertions(+), 248 deletions(-)` and write to variable
+changed_loc=$(git diff --shortstat ${source_branch} ':(exclude)*.lock' \
+        | awk '{ print $4+$6 }' \
+        | awk -F- '{print $NF}' \
+        | bc)
+
+if [[ $changed_loc -le $MAX_CHANGED_LOC ]]; then
+  echo "✅ ${changed_loc} lines of code changed. It is allowed to create Pull Request"
+  exit 0
+else
+  echo "❌ ${changed_loc} lines of code changed. It is more than allowed ${MAX_CHANGED_LOC}. Please divide changes into several branches"
+  exit 1
+fi


### PR DESCRIPTION
See fork's [PR](https://github.com/nifadyev/evrone-django-template/pull/1) for error message and workflow [usage](https://github.com/nifadyev/evrone-django-template/actions) examples

Local shell script is simple and not really convenient. If you know universal `git` command to find parent commit of current branch, let me know (I have tried options from [this](https://gist.github.com/joechrysler/6073741) Gist, and there is no universal command)