### PR TITLE
Add typos spell checker as pre-commit hook and Github Action

### DIFF
--- a/{{cookiecutter.project_name}}/.github/workflows/pr.yaml
+++ b/{{cookiecutter.project_name}}/.github/workflows/pr.yaml
@@ -19,3 +19,6 @@ jobs:
         with:
           target_branch: ${{ github.event.pull_request.base.ref }}
           max_lines_changed: 100
+
+      - name: Spell Check
+        uses: crate-ci/typos@master

--- a/{{cookiecutter.project_name}}/.pre-commit-config.yaml
+++ b/{{cookiecutter.project_name}}/.pre-commit-config.yaml
@@ -2,6 +2,11 @@ default_language_version:
     python: python3.12
 
 repos:
+  - repo: https://github.com/crate-ci/typos
+    rev: v1.24.1
+    hooks:
+      - id: typos
+
   - repo: local
     hooks:
       - id: black


### PR DESCRIPTION
English-only spell checking for source code. It won't catch every typo but it may help with frequent and obvious typos.

`cspell` was also considered since it is default `vs code` spell checker and have multi language support but unfortunately it won't work as `github action` or `pre-commit` hook. See workflow [logs](https://github.com/nifadyev/evrone-django-template/actions/runs/10614928716/job/29421902513) and [issue](https://github.com/streetsidesoftware/cspell/discussions/3426)

`typos` found 1 of 2 typos - workflow [logs](https://github.com/nifadyev/evrone-django-template/actions/runs/10614891888/job/29421790865)