### PR TITLE
#17: Add vulnerability scanner

### DIFF
--- a/{{cookiecutter.project_name}}/.github/workflows/pr.yaml
+++ b/{{cookiecutter.project_name}}/.github/workflows/pr.yaml
@@ -22,3 +22,8 @@ jobs:
 
       - name: Spell Check
         uses: crate-ci/typos@master
+
+      - name: Check project dependencies for vulnerabilities
+        uses: pypa/gh-action-pip-audit@v1.1.0
+        with:
+          vulnerability-service: osv

--- a/{{cookiecutter.project_name}}/.pre-commit-config.yaml
+++ b/{{cookiecutter.project_name}}/.pre-commit-config.yaml
@@ -6,6 +6,11 @@ repos:
     rev: v1.24.1
     hooks:
       - id: typos
+  - repo: https://github.com/pypa/pip-audit
+    rev: v2.7.3
+    hooks:
+      -   id: pip-audit
+          args: ["--vulnerability-service", "osv", "--cache-dir", ".pip_audit_cache"]
 
   - repo: local
     hooks:

--- a/{{cookiecutter.project_name}}/Makefile
+++ b/{{cookiecutter.project_name}}/Makefile
@@ -86,8 +86,6 @@ lint:
 	PYTHONPATH=./app $(MANAGER) run pylint app
 	PYTHONPATH=./app $(MANAGER) run mypy --namespace-packages --show-error-codes app --check-untyped-defs --ignore-missing-imports --show-traceback
 
-safety:
-	$(MANAGER) run safety check --policy-file=.safety-policy.yml
 
 check-changed-loc:
 	chmod +x ./scripts/pr-max-diff-checker.sh

--- a/{{cookiecutter.project_name}}/pyproject-uv.toml
+++ b/{{cookiecutter.project_name}}/pyproject-uv.toml
@@ -39,9 +39,9 @@ dev-dependencies = [
 {%- elif cookiecutter.linter == 'Ruff' %}
     "ruff==0.5.7",
 {%- endif %}
+    "pip-audit==2.7.3",
     "mypy==1.9.0",
     "pylint==3.1.0",
-    "safety==3.1.0",
 ]
 
 {%- if cookiecutter.linter == 'Flake8' %}

--- a/{{cookiecutter.project_name}}/pyproject.toml
+++ b/{{cookiecutter.project_name}}/pyproject.toml
@@ -37,10 +37,10 @@ flake8-rst-docstrings = "^0.3.0"
 {%- elif cookiecutter.linter == 'Ruff' %}
 ruff = "^0.5.7"
 {%- endif %}
+pip-audit="^2.7.3"
 mypy = "^1.9.0"
 pylint = "^3.1.0"
 pylint-django = "^2.5.4"
-safety = "^3.1.0"
 pytest-randomly = "^3.15.0"
 faker = "^28.4.1"
 factory-boy = "^3.3.1"


### PR DESCRIPTION
In order to avoid dependency hell, `pip-audit` is not listed as `dev` dependency. Only `pre-commit` hook and `CI` check is used

Resolves #17 

Request review from @soltanoff 