### PR TITLE
#18: Add checker for unused and undeclared dependencies

### DIFF
--- a/{{cookiecutter.project_name}}/.pre-commit-config.yaml
+++ b/{{cookiecutter.project_name}}/.pre-commit-config.yaml
@@ -30,3 +30,8 @@ repos:
         entry: ruff check app
         language: python
         types: [python]
+      - id: unused_undeclared_deps
+        name: unused_undeclared_deps
+        entry: deptry backend
+        language: python
+        types: [python]

--- a/{{cookiecutter.project_name}}/Makefile
+++ b/{{cookiecutter.project_name}}/Makefile
@@ -84,6 +84,7 @@ lint:
 	make check
 	@# For some reason, mypy and pylint fails to resolve PYTHONPATH, set manually.
 	PYTHONPATH=./app $(MANAGER) run pylint app
+	$(MANAGER) run deptry backend
 	PYTHONPATH=./app $(MANAGER) run mypy --namespace-packages --show-error-codes app --check-untyped-defs --ignore-missing-imports --show-traceback
 
 

--- a/{{cookiecutter.project_name}}/pyproject.toml
+++ b/{{cookiecutter.project_name}}/pyproject.toml
@@ -44,6 +44,7 @@ pylint-django = "^2.5.4"
 pytest-randomly = "^3.15.0"
 faker = "^28.4.1"
 factory-boy = "^3.3.1"
+deptry = "0.21.1"
 
 {%- if cookiecutter.linter == 'Flake8' %}
 


### PR DESCRIPTION
The PR contains configuration examples for [deptry](https://github.com/fpgmaas/deptry) and [fawltydeps](https://github.com/tweag/FawltyDeps).

The main differences are:

- `deptry` unable to find such undeclared dependencies as `celery`,
- `fawltydeps` requires fine-grained configuration to avoid false positives like `django` (`Django` in `pyproject.toml`). `deptry` converts package names to `camel_case` if necessary
- both have custom mapping for such packages as `django-environ` (imported as `environ`)
- `deptry` requires more configuration for `Django` projects to avoid false positives for packages which are not used in codebase (for example, `django-cors-headers`)
- `fawltydeps` unable to resolve packages from private pypi (`core-python-client`, .etc)

As a result, neither of these tools is good enough. But they can be used in tandem to achieve desired behavior. Unfortunately, with extra configuration.

Detailed output could be found in [deptry_worklogs_toggl_output.txt](https://github.com/user-attachments/files/18060972/deptry_worklogs_toggl_output.txt) and [fawltydeps_worklogs_toggl_output.txt](https://github.com/user-attachments/files/18060974/fawltydeps_worklogs_toggl_output.txt)

Resolves #18

